### PR TITLE
Fix fstring python check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}",
+    python_requires=">={}.{}".format(REQUIRED_MAJOR, REQUIRED_MINOR),
     install_requires=[
         "torch>=1.6.0",
     ],


### PR DESCRIPTION
f-strings are only available in >=3.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stefanwebb/flowtorch/19)
<!-- Reviewable:end -->
