### PR TITLE
Avoid select/cat/unbind in AffineAR inverse

### DIFF
--- a/flowtorch/bijectors/affine_autoregressive.py
+++ b/flowtorch/bijectors/affine_autoregressive.py
@@ -57,7 +57,7 @@ class AffineAutoregressive(flowtorch.Bijector):
                 )
             )  # * 10
             mean = mean[..., idx]
-            x[idx] = (y[..., idx] - mean) * inverse_scale
+            x[..., idx] = (y[..., idx] - mean) * inverse_scale
 
         return x
 

--- a/flowtorch/bijectors/affine_autoregressive.py
+++ b/flowtorch/bijectors/affine_autoregressive.py
@@ -43,14 +43,12 @@ class AffineAutoregressive(flowtorch.Bijector):
         self, y: torch.Tensor, params: Optional[flowtorch.ParamsModule]
     ) -> torch.Tensor:
         assert isinstance(params, flowtorch.ParamsModule)
-        x_size = y.size()[:-1]
-        input_dim = y.size(-1)
-        x = [torch.zeros(x_size, device=y.device)] * input_dim
+        x = torch.zeros_like(y)
 
         # NOTE: Inversion is an expensive operation that scales in the
         # dimension of the input
         for idx in params.permutation:  # type: ignore
-            mean, log_scale = params(torch.stack(x, dim=-1))
+            mean, log_scale = params(x.clone())
             inverse_scale = torch.exp(
                 -clamp_preserve_gradients(
                     log_scale[..., idx],
@@ -61,7 +59,7 @@ class AffineAutoregressive(flowtorch.Bijector):
             mean = mean[..., idx]
             x[idx] = (y[..., idx] - mean) * inverse_scale
 
-        return torch.stack(x, dim=-1)
+        return x
 
     def _log_abs_det_jacobian(
         self, x: torch.Tensor, y: torch.Tensor, params: Optional[flowtorch.ParamsModule]

--- a/flowtorch/distributions/transformed_distribution.py
+++ b/flowtorch/distributions/transformed_distribution.py
@@ -76,7 +76,7 @@ class TransformedDistribution(dist.Distribution):
             self.bijector.log_abs_det_jacobian(x, y, self.params()),
             event_dim - self.bijector.event_dim,
         )
-        log_prob = log_prob + _sum_rightmost(
+        log_prob += _sum_rightmost(
             self.base_dist.log_prob(x),
             event_dim - len(self.base_dist.event_shape),
         )


### PR DESCRIPTION
Profiling with the following code:
```
flow = flowtorch.bijectors.Compose([
    flowtorch.bijectors.AffineAutoregressive(
        flowtorch.params.DenseAutoregressive(),
    ) for _ in range(num_blocks)
])

base_dist = dist.Normal(loc=torch.zeros(d).cuda(), scale=torch.ones(d).cuda())
new_dist, flow_params = flow(base_dist)

flow_params.cuda()

optimizer = optim.Adam(flow_params.parameters(), lr=lr, weight_decay=1e-6)
torch.autograd.set_detect_anomaly(True)

flow_params.train()
train_loss = 0

for batch_idx, data in enumerate(train_loader):
    data = data[0]
    data = data.to(device)

    with profiler.profile(with_stack=True, use_cuda=True, record_shapes=True) as prof:
        optimizer.zero_grad()
        loss = -new_dist.log_prob(data).mean()
        train_loss += loss.item()
        loss.backward()
        optimizer.step()


    break
```
on MINIBOONE (from UCI) dataset.

Before:

```
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                               Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  Source Location                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                        aten::addmm         5.77%     896.742ms         6.85%        1.065s       2.366ms        1.063s         7.24%        1.063s       2.363ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1690): linear  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(121):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                       aten::select         6.00%     933.231ms         6.18%     960.762ms      99.747us     957.816ms         6.52%     957.816ms      99.441us          9632  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(63  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-5-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
                        aten::stack         1.34%     208.227ms        11.40%        1.773s       8.245ms     889.219ms         6.06%        1.777s       8.266ms           215  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(54  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-5-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
                         aten::_cat         0.66%     102.592ms         5.21%     809.814ms       3.767ms     813.688ms         5.54%     813.688ms       3.785ms           215  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(54  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-5-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
                       aten::unbind         5.00%     777.298ms        10.02%        1.558s       7.245ms     779.088ms         5.31%        1.557s       7.243ms           215  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(63  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-5-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
Self CPU time total: 15.544s
CUDA time total: 14.683s
```

After:

```
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                               Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  Source Location                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                        aten::addmm         3.46%     429.586ms         4.68%     581.227ms       1.292ms     580.649ms         5.03%     580.649ms       1.290ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1690): linear  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(121):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                          aten::mul         4.12%     510.793ms         4.32%     536.335ms     601.273us     538.297ms         4.66%     538.297ms     603.472us           892  /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(120):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(51): forward                  
                                                                                                                                                                                                                                                              
                        aten::prelu         3.72%     461.920ms         5.19%     644.142ms       1.431ms     513.213ms         4.45%     644.639ms       1.433ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1333): prelu   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/activation.py(1046)  
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                          aten::mul         2.96%     367.125ms         3.06%     379.464ms     441.237us     380.264ms         3.30%     380.264ms     442.168us           860  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(63  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-8-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
                          aten::neg         2.54%     315.529ms         3.46%     429.873ms     499.852us     335.149ms         2.90%     431.055ms     501.227us           860  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(56  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-8-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
Self CPU time total: 12.413s
CUDA time total: 11.540s

```