### PR TITLE
Use split/views to avoid reshapes in DenseAR hypernet

### DIFF
--- a/flowtorch/params/dense_autoregressive.py
+++ b/flowtorch/params/dense_autoregressive.py
@@ -215,15 +215,13 @@ class DenseAutoregressive(flowtorch.Params):
                 hidden_dims[0],
                 self.masks[0],
             ),
-            # torch.nn.PReLU(num_parameters=hidden_dims[0], init=1.0),
-            torch.nn.ReLU(),
+            torch.nn.PReLU(num_parameters=hidden_dims[0], init=1.0),
         ]
         for i in range(1, len(hidden_dims)):
             layers.extend(
                 [
                     MaskedLinear(hidden_dims[i - 1], hidden_dims[i], self.masks[i]),
-                    torch.nn.ReLU(),
-                    # torch.nn.PReLU(num_parameters=hidden_dims[i], init=1.0),
+                    torch.nn.PReLU(num_parameters=hidden_dims[i], init=1.0),
                 ]
             )
         layers.append(

--- a/flowtorch/params/dense_autoregressive.py
+++ b/flowtorch/params/dense_autoregressive.py
@@ -215,13 +215,15 @@ class DenseAutoregressive(flowtorch.Params):
                 hidden_dims[0],
                 self.masks[0],
             ),
-            torch.nn.PReLU(num_parameters=hidden_dims[0], init=1.0),
+            # torch.nn.PReLU(num_parameters=hidden_dims[0], init=1.0),
+            torch.nn.ReLU(),
         ]
         for i in range(1, len(hidden_dims)):
             layers.extend(
                 [
                     MaskedLinear(hidden_dims[i - 1], hidden_dims[i], self.masks[i]),
-                    torch.nn.PReLU(num_parameters=hidden_dims[i], init=1.0),
+                    torch.nn.ReLU(),
+                    # torch.nn.PReLU(num_parameters=hidden_dims[i], init=1.0),
                 ]
             )
         layers.append(
@@ -319,8 +321,9 @@ class DenseAutoregressive(flowtorch.Params):
                 x.size()[: -len(self.input_shape)]
                 + (self.output_multiplier, self.input_dims)
             )
+            result = h.split([sl.stop - sl.start for sl in self.param_slices], dim=-2)
             result = tuple(
-                h[..., p_slice, :].reshape(h.shape[:-2] + p_shape + self.input_shape)
-                for p_slice, p_shape in zip(self.param_slices, list(self.param_shapes))
+                h_slice.view(h.shape[:-2] + p_shape + self.input_shape)
+                for h_slice, p_shape in zip(result, list(self.param_shapes))
             )
         return result


### PR DESCRIPTION
Before
```
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                               Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  Source Location                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                        aten::addmm         6.30%     795.551ms         7.71%     974.334ms       2.165ms     973.283ms         8.30%     973.283ms       2.163ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1690): linear  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(121):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                          aten::mul         4.02%     508.471ms         4.95%     625.242ms     700.944us     626.768ms         5.34%     626.768ms     702.654us           892  /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(120):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(51): forward                  
                                                                                                                                                                                                                                                              
                        aten::prelu         3.59%     454.010ms         5.24%     661.544ms       1.470ms     536.183ms         4.57%     662.213ms       1.472ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1333): prelu   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/activation.py(1046)  
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                        aten::slice         3.02%     382.137ms         3.34%     422.500ms     236.562us       0.000us         0.00%       0.000us       0.000us          1786  /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(323):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(322):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(51): forward                  
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                                                                                              
                          aten::mul         2.80%     354.301ms         2.90%     367.039ms     426.789us     367.165ms         3.13%     367.165ms     426.936us           860  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(60  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-8-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
Self CPU time total: 12.637s
CUDA time total: 11.731s

```


After
```
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                               Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  Source Location                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
                        aten::addmm         6.89%     826.151ms         8.54%        1.024s       2.277ms        1.025s         9.08%        1.025s       2.277ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1690): linear  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(121):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                          aten::mul         4.42%     530.598ms         5.37%     644.311ms     722.322us     645.877ms         5.72%     645.877ms     724.077us           892  /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(120):   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(51): forward                  
                                                                                                                                                                                                                                                              
                        aten::prelu         4.10%     491.562ms         6.00%     720.392ms       1.601ms     579.662ms         5.14%     720.240ms       1.601ms           450  /opt/conda/lib/python3.8/site-packages/torch/nn/functional.py(1333): prelu   
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/activation.py(1046)  
                                                                                                                                                                                 /opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py(727): _ca  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/params/dense_autoregressive.py(297):   
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/param.py(75): forward                  
                                                                                                                                                                                                                                                              
                          aten::mul         3.08%     369.963ms         3.19%     382.978ms     445.323us     384.860ms         3.41%     384.860ms     447.512us           860  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(60  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-5-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
                        aten::copy_         2.83%     339.544ms         2.83%     339.544ms     877.375us     339.873ms         3.01%     339.873ms     878.226us           387  /home/jovyan/work/flowtorch/flowtorch/bijectors/affine_autoregressive.py(60  
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijector.py(70): inverse               
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/bijectors/compose.py(72): inverse      
                                                                                                                                                                                 /home/jovyan/work/flowtorch/flowtorch/distributions/transformed_distributio  
                                                                                                                                                                                 <ipython-input-5-9d7b39809a1f>(13): <module>                                 
                                                                                                                                                                                                                                                              
-----------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------------------------------------  
Self CPU time total: 11.997s
CUDA time total: 11.283s

```